### PR TITLE
fix for powercord spotify modal looking borked

### DIFF
--- a/src/channels/_panels.scss
+++ b/src/channels/_panels.scss
@@ -67,7 +67,7 @@
 	}
 
 	// User
-	.container-3baos1 {
+	.panels-j1Uci_ > .container-3baos1 {
 		position: fixed;
 		bottom: 0;
 		left: 0;
@@ -94,7 +94,7 @@
 			height: 42px !important;
 		}
 	}
-	.nameTag-3uD-yy {
+	.panels-j1Uci_ > .container-3baos1 > .nameTag-3uD-yy {
 		display: none;
 	}
 }


### PR DESCRIPTION
this pr fixes the spotify modal looking borked as discussed in the powercord #theme-dev.

Preview:
![image](https://user-images.githubusercontent.com/41871089/137845819-6309af81-c7aa-470f-ba56-da29b0be4c1f.png)
