### PR TITLE
Centered Profile Icon in the bottom-left corner

### DIFF
--- a/src/theme/sidebar/_panels.scss
+++ b/src/theme/sidebar/_panels.scss
@@ -80,6 +80,7 @@
 		border-top: 1px solid var(--border);
 	}
 	.avatarWrapper__500a6 {
+		justify-content: center;
 		flex: 1;
 	}
 }


### PR DESCRIPTION
This was bothering me so I fixed it :3

The profile icon in the bottom left corner on the sidebar was not centered, so I used justify-content to center it

Pretty sure a Vencord plugin was causing this by widening the sidebar but I can't seem to figure out which one... 

**Before**:

![image](https://github.com/DiscordStyles/SoftX/assets/95449321/b8534aca-e0d7-49d0-87e8-40bd591ebd6d)

**After**:

![image](https://github.com/DiscordStyles/SoftX/assets/95449321/471163d6-e92e-4ad5-9f78-a636a51d1680)

