### PR TITLE
Fixed open chat button in vc

### DIFF
--- a/src/theme/chat/_call.scss
+++ b/src/theme/chat/_call.scss
@@ -5,4 +5,8 @@
 	.wrapper__6bf2d.minimum__7f356 {
 		height: 300px;
 	}
+	.chatButton_a40cc3 {
+		top: 25px;
+    	right: 187px;
+	}
 }

--- a/src/theme/chat/_call.scss
+++ b/src/theme/chat/_call.scss
@@ -7,6 +7,6 @@
 	}
 	.chatButton_a40cc3 {
 		top: 25px;
-    	right: 187px;
+    		right: 187px;
 	}
 }


### PR DESCRIPTION
Moved the open chat button for embedded chats in text channels

(And yes, I lined it up pixel-perfect which is why I had to use these icky numbers)

```
.chatButton_a40cc3 {
	top: 25px;
    	right: 187px;
}
```

I put it in _call.scss cause it makes sense :3

Before:
![image](https://github.com/DiscordStyles/SoftX/assets/95449321/e4470d42-9417-48a4-a34b-d3865f11b54a)


After:
![image](https://github.com/DiscordStyles/SoftX/assets/95449321/fda033a2-b288-43c4-a642-7ceaf1b4bc5b)
