### PR TITLE
Fixed the roles settings menu

### DIFF
--- a/src/theme/settings/_content.scss
+++ b/src/theme/settings/_content.scss
@@ -51,13 +51,14 @@
 	
 	//Fixing the roles tab. Why is the roles tab so different from the others? WHY?
 	.contentColumnMinimal__7b4f5{
-		padding-right: 0px;
+		padding-right: 0px !important;
 		.customColumn__0b6a6 {
 			width: 100%;
 			max-width: 100%;
 		}
 		.content__690c5 {
 			padding: 0px 70px 0px 0px;
+			border-right: none;
 		}
 		.page_c3ed26{
 			width: 100%;
@@ -67,5 +68,24 @@
 			width: 100%;
 			max-width: 100%;
 		}
+		.header_ee0bd9,
+		.headerContainer__282e2{
+			min-width: 100%;
+			margin-right: -6px;
+			border-right: none;
+		}
 	}
+	.contentRegionShownSidebar__9d1b9{
+		overflow: hidden !important;
+	}
+	.titleContainer_d09261{
+		background: transparent;
+	}
+	.header_ee0bd9 {
+		border-radius: 5px;
+		.menu__22341 {
+			padding-right: 10px;
+		}
+	}
+
 }

--- a/src/theme/settings/_content.scss
+++ b/src/theme/settings/_content.scss
@@ -25,6 +25,7 @@
 		padding: 32px;
 		z-index: 1;
 	}
+
 	// Custom scroller bullshit. Why Discord. WHY?
 	.customColumn__0b6a6,
 	.contentColumn__5f80b {
@@ -46,24 +47,5 @@
 		width: 100%;
 		max-height: var(--settings-max-height);
 		max-width: var(--settings-content-width);
-	}
-	//Fixing the roles tab. Why is the roles tab so different from the others? WHY?
-	.contentColumnMinimal__7b4f5{
-		padding-right: 0px;
-		.customColumn__0b6a6 {
-			width: 100%;
-			max-width: 100%;
-		}
-		.content__690c5 {
-			padding: 0px 70px 0px 0px;
-		}
-		.page_c3ed26{
-			width: 100%;
-			max-width: 100%;
-		}
-		.contentWidth_f1e6d4{
-			width: 100%;
-			max-width: 100%;
-		}
 	}
 }


### PR DESCRIPTION
Fixes:

- Roles screen width being limited
- Double scroll bar in certain screens
- Made the header match the theme a little better
- Way too many other small changes 

Before:
![image](https://github.com/DiscordStyles/SoftX/assets/95449321/8b076790-861e-4e39-b5c4-2b161cc13dcf)
![image](https://github.com/DiscordStyles/SoftX/assets/95449321/4a5e93a2-37ec-4385-9198-2b50e88a351b)

After:
![image](https://github.com/DiscordStyles/SoftX/assets/95449321/6cdc938a-0628-4ad8-b0ce-d2889be6eb65)
![image](https://github.com/DiscordStyles/SoftX/assets/95449321/d54adbd5-8a87-4d16-be90-2d9fa9a5a753)
