### PR TITLE
Made the top bar of the client grabbable 

### DIFF
--- a/src/theme/app/_toolbar.scss
+++ b/src/theme/app/_toolbar.scss
@@ -151,4 +151,12 @@
 	.threadSidebarOpen__62c31 .container__26baa {
 		border-right: 1px solid var(--border);
 	}
+
+	// Makes the top bar more easily grabbable
+	.titleBar__710b0  {
+		height: 20px;
+		-webkit-app-region: drag;
+		pointer-events: none;
+		top: 0;
+	}
 }


### PR DESCRIPTION
Also had to make sure it didn't cover the buttons below
Also, it disappears when using Vencord's "show Windows native title bar" option