### PR TITLE
Free performance

### DIFF
--- a/src/core/_root.scss
+++ b/src/core/_root.scss
@@ -10,7 +10,7 @@
 	/*
 	 * SoftX variables
 	 */
-	--background-image: url('https://i.imgur.com/Nglfni6.png'); /* Background image | URL MUST BE A DIRECT LINK (ending in .jpg, .jpeg, .png, .gif) */
+	--background-image: url('https://i.imgur.com/BY0CkxE.png'); /* Background image | URL MUST BE A DIRECT LINK (ending in .jpg, .jpeg, .png, .gif) */
 	--background-blur: 0px; /* Blur intensity of --background-image | Must end in px | Default: 0px */
 
 	--accent: 0, 231, 169; /* Colour used around the app. | Values are in R,G,B format. | Default: 0, 231, 169 */


### PR DESCRIPTION
Resized bg image from 2560x1440 to 16x9 pixels, and because its blurred there is no difference even with opacity 0, In its even higher quality because its gpu interpolated.

Lets have fun! Which is the image with 25 600 times more pixels?

number one
![image](https://github.com/DiscordStyles/SoftX/assets/40531871/66391d1e-f0d2-473c-8b13-2b3673e62b38)

or number two
![image](https://github.com/DiscordStyles/SoftX/assets/40531871/078c6483-cf95-4253-9630-784955a5df35)
