### PR TITLE
Fixed the thing

### DIFF
--- a/src/theme/app/_toolbar.scss
+++ b/src/theme/app/_toolbar.scss
@@ -160,3 +160,19 @@
 		top: 0;
 	}
 }
+
+//fixed the shit -lion
+.platform-win .winButton_a934d8 {
+	height: 74px
+}
+.toolbar_fc4f04 {
+	margin-right: 150px;
+}
+.theme-dark .themed_fc4f04 {
+	background: var(--bg-secondary);
+	height: 74px;
+	border-bottom: 1px solid var(--border);
+}
+.theme-dark .children_fc4f04:after {
+	background: transparent;
+}

--- a/src/theme/chat/_call.scss
+++ b/src/theme/chat/_call.scss
@@ -9,4 +9,10 @@
 		top: 25px;
     		right: 187px;
 	}
+	.children_fc4f04 {
+		height: 60px;
+	}
+	.disabledButtonWrapper_dd4f85 .button_dd4f85.grow_dd4f85 {
+		margin-left: 18px;
+	}
 }


### PR DESCRIPTION
Broken:
![image](https://github.com/user-attachments/assets/ed27c7b7-2431-436c-9076-457abc7aa382)

Not broken:
![image](https://github.com/user-attachments/assets/683409eb-9064-4ca8-9282-e13ec2af2210)
