### PR TITLE
Fix vertical user area & server discovery button

### DIFF
--- a/src/addons/_verticaluserarea.scss
+++ b/src/addons/_verticaluserarea.scss
@@ -3,11 +3,16 @@
 		.tree_fea3ef {
 			outline: none !important;
 		}
-		.scroller_fea3ef {
-			margin-bottom: var(--user-area, 220px);
-		}
 		.unreadMentionsIndicatorBottom_fea3ef {
 			bottom: calc(var(--user-area) + 10px);
+		}
+		// Discovery button
+		.footer_aa1bff {
+			width: 100%;
+			margin-bottom: var(--user-area, 225px);
+			.listItem_c96c45 {
+				margin-bottom: 0px;
+			}
 		}
 	}
 

--- a/src/addons/_verticaluserarea.scss
+++ b/src/addons/_verticaluserarea.scss
@@ -9,7 +9,7 @@
 		// Discovery button
 		.footer_aa1bff {
 			width: 100%;
-			margin-bottom: var(--user-area, 225px);
+			margin-bottom: var(--user-area, 220px);
 			.listItem_c96c45 {
 				margin-bottom: 0px;
 			}

--- a/src/theme/guilds/_server.scss
+++ b/src/theme/guilds/_server.scss
@@ -1,9 +1,9 @@
 #app-mount {
-	.wrapper-28eC3z {
+	.wrapper_c5f96a {
 		width: var(--server-size);
 		height: var(--server-size);
 	}
-	.svg-2zuE5p {
+	.svg_c5f96a {
 		width: var(--server-size);
 		height: var(--server-size);
 	}


### PR DESCRIPTION
A recent discord layout change moved the "discover servers" button to a footer below the server scroller. Currently on SoftX, when using the vertical user area addon, this button clips with the user area and an empty space is left below the server scroller.

Before:
![1](https://github.com/user-attachments/assets/91cee973-7920-4964-995d-fcb78d8577ae)

After:
![2](https://github.com/user-attachments/assets/023aaf8a-5fb3-49a3-a32a-30618eecd6ce)

My commit also updates the classes in `src/theme/guilds/_server.scss` which seem to have been left untouched.

Please let me know if I've made any errors :)