### PR TITLE
Update some message accessories (reaction btn, file attachment, voice message)

### DIFF
--- a/src/theme/chat/_message.scss
+++ b/src/theme/chat/_message.scss
@@ -170,4 +170,13 @@ body,
 		background: rgb(255 255 255 / 0.05);
 		border: none;
 	}
+
+	// Attachments
+	.attachment_b52bef {
+		background: rgb(255 255 255 / 0.03);
+	}
+	// Voice message
+	.container_d6cb89 {
+		background: rgb(255 255 255 / 0.03);
+	}
 }

--- a/src/theme/chat/_reactions.scss
+++ b/src/theme/chat/_reactions.scss
@@ -1,9 +1,9 @@
 #app-mount {
-	.reaction_f61c73 {
+	.reaction_ec6b19, .reactionBtn_ec6b19 {
 		background: rgb(255 255 255 / 0.05);
 		border-radius: 6px;
 		border: none;
-		&.reactionMe_f61c73 {
+		&.reactionMe_ec6b19 {
 			background: rgb(var(--accent), 0.15);
 			.reactionCount-1zkLcN {
 				color: rgb(var(--accent));


### PR DESCRIPTION
* Updates reaction class
* Makes reaction styling apply to reaction button as well. I'm pretty sure the reaction button used to also have the reaction class, but that was removed at some point recently.
* Apply message embed background to file attachments and voice messages
  * Again I'm pretty sure this was the case before some kind of discord update recently. It seems like message attachments used to have a generic "embed" class which `_message.scss` targeted, but now message accessories have been separated out into other classes.