### PR TITLE
Update textbox classes and selectors

### DIFF
--- a/src/theme/chat/_textbox.scss
+++ b/src/theme/chat/_textbox.scss
@@ -25,21 +25,23 @@
 		.button_dd4f85 {
 			height: 100%;
 			// Gif Button
-			#icon {
-				svg {
-					mask: url(assets.$icon_photograph) center/cover;
-					background: var(--interactive-muted);
-					transition: var(--transition);
-					transition-property: background;
-					path {
-						display: none;
+			&[aria-label="Open GIF picker"] {
+				.lottieIcon_f73ef7 {
+					svg {
+						mask: url(assets.$icon_photograph) center/cover;
+						background: var(--interactive-muted);
+						transition: var(--transition);
+						transition-property: background;
+						path {
+							display: none;
+						}
 					}
 				}
+				&:hover .lottieIcon_f73ef7 svg {
+					background: var(--interactive-normal);
+				}
 			}
-			&:hover #icon svg {
-				background: var(--interactive-normal);
-			}
-			&:not(.attachButton_f298d4) {
+			&:not(.attachButton_bdf0de) {
 				svg {
 					transition: var(--transition);
 					transition-property: filter;
@@ -52,7 +54,7 @@
 				}
 			}
 		}
-		.emojiButton_d0696b {
+		.emojiButton_d91a75 {
 			padding: 0 4px;
 			max-height: 54px;
 			.sprite_d91a75 {
@@ -69,7 +71,7 @@
 				background: var(--interactive-normal);
 			}
 		}
-		.stickerButton_d0696b {
+		.stickerButton_bdf0de {
 			padding: 0;
 			svg {
 				width: 24px !important;
@@ -112,10 +114,10 @@
 	.placeholder_a552a6 {
 		padding: 16px 0;
 	}
-	.scrollableContainer_d0696b {
+	.scrollableContainer_bdf0de {
 		background: transparent;
 	}
-	.attachButton_f298d4 {
+	.attachButton_bdf0de {
 		height: 100%;
 		svg {
 			mask: url(assets.$icon_paper-clip) center/cover;
@@ -137,7 +139,7 @@
 		}
 	}
 
-	.buttons_d0696b {
+	.buttons_bdf0de {
 		min-height: 54px;
 		& > button[aria-label] {
 			svg {
@@ -161,7 +163,7 @@
 	}
 
 	// Replying
-	.attachedBars_d0696b {
+	.stackedBars_bdf0de {
 		background: transparent;
 		border-radius: 6px 6px 0 0;
 	}


### PR DESCRIPTION
Updates class selectors for the chat textbox.

Notes:
* Discord's previous use of `#icon` has been replaced with a class, `.lottieIcon_f73ef7`.
* Selector for Gif Button had to be specified using `aria-label`, otherwise the selector also targeted sticker and emoji buttons.
* This block
```
&:hover #icon svg {
    background: var(--interactive-normal);
}
```
had to be moved to within the Gif Button selector (now `&:hover .lottieIcon_f73ef7 svg`), otherwise this block also affected the Nitro gift button when hovering.

In these screenshots I have a few extra buttons, that's just some plugins from Vencord :)

Let me know if there's any problems!

## Before:
![old](https://github.com/user-attachments/assets/71141ed4-0abe-4245-bbb0-ebd96698b81d) ![old hi](https://github.com/user-attachments/assets/c1ffeffa-8a23-43ad-b468-6a8758fd1d3e)

## After:
![new](https://github.com/user-attachments/assets/76329d73-3d9c-4729-820a-08f099ab0d6a) ![new hi](https://github.com/user-attachments/assets/6303df6f-acfb-4910-846d-3aacaf85c8f2)
