### PR TITLE
Update verticaluserarea guild browser footer class

### DIFF
--- a/src/addons/_verticaluserarea.scss
+++ b/src/addons/_verticaluserarea.scss
@@ -7,7 +7,7 @@
 			bottom: calc(var(--user-area) + 10px);
 		}
 		// Discovery button
-		.footer_aa1bff {
+		.footer_f8ec41 {
 			width: 100%;
 			margin-bottom: var(--user-area, 220px);
 			background: transparent;


### PR DESCRIPTION
The class of the `.footer` element holding the server discovery button and gradient was updated again.

The server discovery button itself was also gone. You can't see it in my screenshots but I confirmed that the button still doesn't overlap with the rest of the guild scroller.

Before: (it's hard to see because of the default background, but there's a dark gradient at the bottom, and the discovery button is behind my avatar)
![before-discovery](https://github.com/user-attachments/assets/b3e3f3d8-64c7-4f02-8a99-a4b1f575bbc7)
After:
![after-discovery](https://github.com/user-attachments/assets/70a9efc6-9f3c-445d-a580-f29933070a40)