### PR TITLE
Fix background of spoilered attachments vs nonspoilered

### DIFF
--- a/src/theme/chat/_message.scss
+++ b/src/theme/chat/_message.scss
@@ -172,6 +172,9 @@ body,
 	}
 
 	// Attachments
+	.spoilerContainer_aa9639 {
+		background: none;
+	}
 	.attachment_b52bef {
 		background: rgb(255 255 255 / 0.03);
 	}


### PR DESCRIPTION
I don't know if this change was recent, but it looks like spoilered attachments have more background provided by a parent element `.spoilerContainer`. I've removed that here so spoilered and nonspoilered attachments have the same custom background set by SoftX.

Before:
![before-attachments](https://github.com/user-attachments/assets/cded641c-2d91-4cf2-b5d8-df5279ad066f)
After:
![after-attachments](https://github.com/user-attachments/assets/c9ed9629-74b6-4d38-8471-ecd1ce40e248)