### PR TITLE
Reposition inbox tab elements

### DIFF
--- a/src/theme/popouts/_inbox.scss
+++ b/src/theme/popouts/_inbox.scss
@@ -18,6 +18,12 @@
 		background: transparent;
 		border-bottom: 1px solid var(--border);
 		padding: 0;
+		.headerTabs_f0cd33 {
+			margin: 0;
+			.tabBar_f0cd33 {
+				margin: 0;
+			}
+		}
 		.button__292b6 {
 			height: 55px;
 			margin: 0;
@@ -28,7 +34,7 @@
 				background: var(--background-modifier-hover);
 			}
 		}
-		min-height: 90px;
+		min-height: fit-content;
 		.expanded_f0cd33 {
 		}
 		.expandedInboxHeader_f0cd33 {
@@ -45,7 +51,7 @@
 		}
 	}
 	.tab_f0cd33 {
-		height: 55px;
+		height: 45px;
 		padding: 0 12px;
 		margin: 0;
 		border-radius: 0;


### PR DESCRIPTION
Updates the position and size of some elements in the "inbox" popout.

Currently, the tabs are offset to the left and cropped out of view. Also, the size of the header section is inconsistent and in the "unread" and "mentions" tabs, it doesn't contain all the tabs, which overlap onto the contents.

Before:
![before-inbox](https://github.com/user-attachments/assets/de361a72-7de8-4532-a50c-b961b8f44294)
After:
![after-inbox](https://github.com/user-attachments/assets/691daefa-1977-42fb-b730-893a9aac60c4)